### PR TITLE
Fix empty url path redirecting to Safari View

### DIFF
--- a/XXXApolloOpener.m
+++ b/XXXApolloOpener.m
@@ -18,18 +18,18 @@
 }
 
 - (id)openURL:(NSURL *)url sender:(NSString *)sender {
-	NSString *urlString = [url.absoluteString lowercaseString];
-    if ([url.host isEqualToString:@"www.m.reddit.com"] || [url.host isEqualToString:@"www.reddit.com"] || [url.host isEqualToString:@"m.reddit.com"] || [url.host isEqualToString:@"reddit.com"] || [url.host containsString:@".reddit.com"]) {
-		if([urlString containsString:@"https"]){
-			urlString = [urlString stringByReplacingOccurrencesOfString:@"https" withString:@"apollo"];
-		}else if([urlString containsString:@"http"]){
-			urlString = [urlString stringByReplacingOccurrencesOfString:@"http" withString:@"apollo"];
-		}
-		
-		if([urlString isEqualToString:@"apollo://www.reddit.com/"] || [urlString isEqualToString:@"apollo://reddit.com/"] || [urlString isEqualToString:@"apollo://www.reddit.com"] || [urlString isEqualToString:@"apollo://reddit.com"]){
-			urlString = @"apollo://";
-		}
-        return [NSURL URLWithString:urlString];
+	
+    if ([url.host isEqualToString:@"www.reddit.com"] ||
+        [url.host isEqualToString:@"reddit.com"] ||
+        [url.host isEqualToString:@"m.reddit.com"] ||
+        [url.host isEqualToString:@"old.reddit.com"] ||
+        [url.host containsString:@".reddit.com"]) {
+        
+        if ([url.path isEqualToString:@"/"]) {
+            return [NSURL URLWithString:@"apollo://"];
+        } else {
+            return [NSURL URLWithString:[NSString stringWithFormat:@"apollo://reddit.com%@/?%@", url.path, url.query]];
+        }
     }
 
     return nil;


### PR DESCRIPTION
Hey @gilshahar7, this pull request fixes a pretty rare issue that I discovered while using your tweak.

If you were to open [https://old.reddit.com/](https://old.reddit.com/) or [https://m.reddit.com/](https://m.reddit.com/), Apollo will open a Safari View instead of the "Home" page.

I've tested it on Apollo v1.2.3 on iOS 11.3.1 and libopener v3.2.2

Cheers,
Yaowei