### PR TITLE
Add support for `reddit.app.link` and Apollo unsupported paths

### DIFF
--- a/XXXApolloOpener.m
+++ b/XXXApolloOpener.m
@@ -47,6 +47,18 @@
 }
 
 - (NSURL *)createApolloURLFromURL:(NSURL *)url {
+    // If URL is /r/:subreddit/wiki or (/about), let the Official Reddit app handle
+    if (url.pathComponents.count >= 4 &&
+            ([url.pathComponents[3] isEqualToString:@"wiki"] ||
+            [url.pathComponents[3] isEqualToString:@"about"])) {
+        return nil;
+    }
+
+    // if URL is /live/, let the Official Reddit app handle
+    if (url.pathComponents.count >= 3 && [url.pathComponents[1] isEqualToString:@"live"]) {
+        return nil;
+    }
+
     if ([url.path isEqualToString:@"/"] || [url.path isEqualToString:@""]) {
         return [NSURL URLWithString:@"apollo://"];
     } else {
@@ -57,7 +69,6 @@
 /*
 Thanks to:
 - https://stackoverflow.com/questions/8756683/best-way-to-parse-url-string-to-get-values-for-keys
-- https://stackoverflow.com/questions/8756683/best-way-to-parse-url-string-to-get-values-for-keys/26406426#26406426
 */
 - (NSString *)valueForKey:(NSString *)key fromQueryItems:(NSArray *)queryItems {
 

--- a/XXXApolloOpener.m
+++ b/XXXApolloOpener.m
@@ -23,16 +23,49 @@
         [url.host isEqualToString:@"reddit.com"] ||
         [url.host isEqualToString:@"m.reddit.com"] ||
         [url.host isEqualToString:@"old.reddit.com"] ||
+        [url.host isEqualToString:@"reddit.app.link"] ||
         [url.host containsString:@".reddit.com"]) {
-        
-        if ([url.path isEqualToString:@"/"] || [url.path isEqualToString:@""]) {
-            return [NSURL URLWithString:@"apollo://"];
-        } else {
-            return [NSURL URLWithString:[NSString stringWithFormat:@"apollo://reddit.com%@/?%@", url.path, url.query]];
+
+        if ([url.host isEqualToString:@"reddit.app.link"]) {
+            NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:url 
+                                                resolvingAgainstBaseURL:NO];
+            NSArray *queryItems = urlComponents.queryItems;
+            NSString *og_redirect = [self valueForKey:@"$og_redirect" 
+                            fromQueryItems:queryItems];
+
+            if ([og_redirect length] != 0) {
+                url = [NSURL URLWithString:og_redirect];
+            } else {
+                return nil;
+            }
         }
+
+        return [self createApolloURLFromURL:url];
     }
 
     return nil;
+}
+
+- (NSURL *)createApolloURLFromURL:(NSURL *)url {
+    if ([url.path isEqualToString:@"/"] || [url.path isEqualToString:@""]) {
+        return [NSURL URLWithString:@"apollo://"];
+    } else {
+        return [NSURL URLWithString:[NSString stringWithFormat:@"apollo://reddit.com%@/?%@", url.path, url.query]];
+    }
+}
+
+/*
+Thanks to:
+- https://stackoverflow.com/questions/8756683/best-way-to-parse-url-string-to-get-values-for-keys
+- https://stackoverflow.com/questions/8756683/best-way-to-parse-url-string-to-get-values-for-keys/26406426#26406426
+*/
+- (NSString *)valueForKey:(NSString *)key fromQueryItems:(NSArray *)queryItems {
+
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"name=%@", key];
+    NSURLQueryItem *queryItem = [[queryItems 
+                                  filteredArrayUsingPredicate:predicate]
+                                 firstObject];
+    return queryItem.value;
 }
 
 @end


### PR DESCRIPTION
It seems that ApolloOpener does not work with Reddit's web banners shown below.

![img_1872](https://user-images.githubusercontent.com/8582659/45419322-99c79900-b6b9-11e8-8cb1-d935c26a62da.PNG)

Reddit's web banner ("OPEN IN APP" and "VIEW IN APP" ) uses the domain [reddit.app.link](https://reddit.app.link/apple-app-site-association) to redirect users to the Official Reddit app.

This pull request fixes that issue by detecting the domain and parses the query parameters for the item `$og_redirect` which contains the original URL the user is on and rewrites the link. There are 2 other possible candidates for the URL extraction (`$deeplink_path ` or `$android_deeplink_path `).

The other issue is that Apollo does not support universal links to Wiki or Live pages so it'll let the Official Reddit app handle it.